### PR TITLE
added pt cnt to recursive curveToPoints

### DIFF
--- a/src/SceneUtilities.js
+++ b/src/SceneUtilities.js
@@ -27,7 +27,7 @@ function curveToPoints (curve, pointLimit) {
     let segmentCount = curve.segmentCount
     for (let i = 0; i < segmentCount; i++) {
       let segment = curve.segmentCurve(i)
-      let segmentArray = curveToPoints(segment)
+      let segmentArray = curveToPoints(segment, pointCount)
       rc = rc.concat(segmentArray)
       segment.delete()
     }


### PR DESCRIPTION
PolyCurves use a recursive call to the curveToPoints function, but didn't include a point count argument.